### PR TITLE
Fix to correct tokenization of the author string. 

### DIFF
--- a/lib/BibTeX/Parser/Entry.pm
+++ b/lib/BibTeX/Parser/Entry.pm
@@ -234,10 +234,6 @@ sub _split_author_field {
 
   return () if !defined $field || $field eq '';
 
-  my @names;
-
-  my $buffer;
-
   my @authors = split /\sand(?![^{]*})\s/i, $field;
   return @authors;
 }

--- a/lib/BibTeX/Parser/Entry.pm
+++ b/lib/BibTeX/Parser/Entry.pm
@@ -230,38 +230,16 @@ sub _handle_author_editor {
 # Split an author field into different author names.
 # Handles quoted names ({name}).
 sub _split_author_field {
-    my $field = shift;
+  my $field = shift;
 
-    return () if !defined $field || $field eq '';
+  return () if !defined $field || $field eq '';
 
-    my @names;
+  my @names;
 
-    my $buffer;
-    while (!defined pos $field || pos $field < length $field) {
-	if ( $field =~ /\G ( .*? ) ( \{ | \s+ and \s+ )/xcgi ) {
-	    my $match = $1;
-	    if ( $2 =~ /and/i ) {
-		$buffer .= $match;
-		push @names, $buffer;
-		$buffer = "";
-	    } elsif ( $2 =~ /\{/ ) {
-		$buffer .= $match . "{";
-		if ( $field =~ /\G (.* \})/cgx ) {
-		    $buffer .= $1;
-		} else {
-		    die "Missing closing brace at " . substr( $field, pos $field, 10 );
-		}
-	    } else {
-		$buffer .= $match;
-	    }
-	} else {
-	   #print "# $field " . (pos ($field) || 0) . "\n";
-	   $buffer .= substr $field, (pos $field || 0);
-	   last;
-	}
-    }
-    push @names, $buffer if $buffer;
-    return @names;
+  my $buffer;
+
+  my @authors = split /\sand(?![^{]*})\s/i, $field;
+  return @authors;
 }
 
 =head2 author([@authors])

--- a/t/04-entry.t
+++ b/t/04-entry.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::More tests => 13;
+use Test::More tests => 14;
 
 use BibTeX::Parser::Entry;
 
@@ -40,3 +40,11 @@ ok($entry->has("title"), "Entry::has true on known value");
 ok($entry->has("year"), "Entry::has true on known value");
 
 ok( ! $entry->has("pages"), "Entry::has false on unknown value");
+
+# check the author splitting code.
+my @authors = BibTeX::Parser::Entry::_split_author_field("{Securities and Exchange Commission (SEC)} and {Barnes' and Noble} and Th{\\'{e}}venaz, Jacques");
+is_deeply(\@authors, [
+  "{Securities and Exchange Commission (SEC)}",
+  "{Barnes' and Noble}",
+  "Th{\\'{e}}venaz, Jacques"
+], "Entry::_split_author_field returns correct number of authors");


### PR DESCRIPTION
I was having trouble when trying to parse author strings that contained '{}'s. I replaced the parsing code with a regular expression which seems to pass the existing tests and an additional test that I added to show how the original code was failing. I hope this is useful.    
